### PR TITLE
Proper use of Path.Join

### DIFF
--- a/tests/JpegLSCodecTest.cs
+++ b/tests/JpegLSCodecTest.cs
@@ -278,7 +278,7 @@ namespace CharLS.Native.Test
 
         private static byte[] ReadAllBytes(string path, int bytesToSkip = 0)
         {
-            var fullPath = DataFileDirectory + path;
+            var fullPath = Path.Join(DataFileDirectory, path);
 
             if (bytesToSkip == 0)
                 return File.ReadAllBytes(fullPath);
@@ -296,7 +296,7 @@ namespace CharLS.Native.Test
             get
             {
                 var assemblyLocation = new Uri(Assembly.GetExecutingAssembly().Location);
-                return Path.GetDirectoryName(assemblyLocation.LocalPath) + @"\DataFiles\";
+                return Path.Join(Path.GetDirectoryName(assemblyLocation.LocalPath), "DataFiles");
             }
         }
 

--- a/tests/JpegLSDecoderTest.cs
+++ b/tests/JpegLSDecoderTest.cs
@@ -151,7 +151,7 @@ namespace CharLS.Native.Test
 
         private static byte[] ReadAllBytes(string path, int bytesToSkip = 0)
         {
-            var fullPath = DataFileDirectory + path;
+            var fullPath = Path.Join(DataFileDirectory, path);
 
             if (bytesToSkip == 0)
                 return File.ReadAllBytes(fullPath);
@@ -169,7 +169,7 @@ namespace CharLS.Native.Test
             get
             {
                 Uri assemblyLocation = new(Assembly.GetExecutingAssembly().Location);
-                return Path.GetDirectoryName(assemblyLocation.LocalPath) + @"\DataFiles\";
+                return Path.Join(Path.GetDirectoryName(assemblyLocation.LocalPath), "DataFiles");
             }
         }
     }


### PR DESCRIPTION
Fix test failure on Linux by removing backslash.

Message was:

System.IO.FileNotFoundException : Could not find file 'charls-native-dotnet/bin/Debug\DataFiles\t8c0e0.jls'.