### PR TITLE
Update NuGet packages to latest versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,10 +1,10 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="nunit" Version="3.13.2" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageVersion Include="System.Drawing.Common" Version="5.0.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.0-beta-20204-02"/>
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1"/>
   </ItemGroup>
 </Project>

--- a/samples/Convert/.globalconfig
+++ b/samples/Convert/.globalconfig
@@ -1,0 +1,11 @@
+# Copyright (c) Team CharLS.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# The following configuration settings are used to control the build-in .NET analyzer in the C# compiler (Roslyn).
+# All warnings are by default enabled in the projects.
+# Some warnings type are however to noisy and not effective and globally disabled.
+is_global = true
+
+# CA1416: This call site is reachable on all platforms. 'Bitmap' is only supported on: 'windows'.
+# Rational: System.Drawing.Common is not supported anymore on Linux. It still works and there are no good alternatives at the moment.
+dotnet_diagnostic.CA1416.severity = none

--- a/samples/Convert/runtimeconfig.template.json
+++ b/samples/Convert/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+    "configProperties": {
+        "System.Drawing.EnableUnixSupport": true
+    }
+}


### PR DESCRIPTION
Official support for System.Drawing.Common on Linux has been dropped in v6. At the moment there is not a good alternative. Use it in the sample code until v7 also disables the current workaround (System.Drawing.EnableUnixSupport).