### PR TITLE
Rename class SafeNativeMethods to Interop

### DIFF
--- a/src/Interop.cs
+++ b/src/Interop.cs
@@ -8,12 +8,12 @@ using System.Runtime.InteropServices;
 
 namespace CharLS.Native;
 
-internal static class SafeNativeMethods
+internal static class Interop
 {
     private const string NativeLibraryName = "charls-2";
 
     [SuppressMessage("Design", "CA1065:Do not raise exceptions in unexpected locations", Justification = "Type is unusable if native DLL doesn't match")]
-    static SafeNativeMethods()
+    static Interop()
     {
         NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), DllImportResolver);
 

--- a/src/JpegLSDecoder.cs
+++ b/src/JpegLSDecoder.cs
@@ -4,7 +4,7 @@
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using static CharLS.Native.SafeNativeMethods;
+using static CharLS.Native.Interop;
 
 namespace CharLS.Native;
 

--- a/src/JpegLSEncoder.cs
+++ b/src/JpegLSEncoder.cs
@@ -4,7 +4,7 @@
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using static CharLS.Native.SafeNativeMethods;
+using static CharLS.Native.Interop;
 
 namespace CharLS.Native;
 

--- a/src/SafeHandleJpegLSDecoder.cs
+++ b/src/SafeHandleJpegLSDecoder.cs
@@ -14,7 +14,7 @@ internal class SafeHandleJpegLSDecoder : SafeHandleZeroOrMinusOneIsInvalid
 
     protected override bool ReleaseHandle()
     {
-        SafeNativeMethods.CharLSDestroyDecoder(handle);
+        Interop.CharLSDestroyDecoder(handle);
         return true;
     }
 }

--- a/src/SafeHandleJpegLSEncoder.cs
+++ b/src/SafeHandleJpegLSEncoder.cs
@@ -14,7 +14,7 @@ internal class SafeHandleJpegLSEncoder : SafeHandleZeroOrMinusOneIsInvalid
 
     protected override bool ReleaseHandle()
     {
-        SafeNativeMethods.CharLSDestroyEncoder(handle);
+        Interop.CharLSDestroyEncoder(handle);
         return true;
     }
 }

--- a/tests/JpegLSDecoderTest.cs
+++ b/tests/JpegLSDecoderTest.cs
@@ -155,7 +155,7 @@ public class JpegLSDecoderTest
 
     internal static bool CanHandleEmptyBuffer()
     {
-        SafeNativeMethods.CharLSGetVersionNumber(out int _, out int minor, out int patch);
+        Interop.CharLSGetVersionNumber(out int _, out int minor, out int patch);
         return minor > 2 || patch > 0;
     }
 


### PR DESCRIPTION
Follow the pattern used by .NET source code. Code access security (CAS) is an unsupported legacy technology.