### PR TITLE
Update to CharLS v2.4.0

### DIFF
--- a/src/ApplicationDataEventArgs.cs
+++ b/src/ApplicationDataEventArgs.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace CharLS.Native;
+
+/// <summary>
+/// Encapsulates event data for ApplicationData event
+/// </summary>
+public sealed class ApplicationDataEventArgs : EventArgs
+{
+    internal ApplicationDataEventArgs(int applicationDataId, byte[] data)
+    {
+        Id = applicationDataId;
+        Data = data;
+    }
+
+    /// <summary>
+    /// Identifies the type of application data, has the range [0,15]
+    /// </summary>
+    public int Id { get; }
+
+    /// <summary>
+    /// Returns the application data.
+    /// </summary>
+    public ReadOnlyMemory<byte> Data { get; }
+
+    /// <summary>
+    /// When set will abort the decoding process.
+    /// </summary>
+    public bool Failed { get; set; }
+}

--- a/src/CharLS.Native.csproj
+++ b/src/CharLS.Native.csproj
@@ -82,9 +82,9 @@
   </ItemGroup>
 
   <Target Name="BuildNativeWindowsCharLS" BeforeTargets="DispatchToInnerBuilds" Condition="'$(MSBuildRuntimeType)'=='Full'">
-    <MSBuild Projects="..\extern\charls\src\CharLS.vcxproj" Targets="Build" Properties="Configuration=$(Configuration);Platform=Win32" />
-    <MSBuild Projects="..\extern\charls\src\CharLS.vcxproj" Targets="Build" Properties="Configuration=$(Configuration);Platform=x64" />
-    <MSBuild Projects="..\extern\charls\src\CharLS.vcxproj" Targets="Build" Properties="Configuration=$(Configuration);Platform=ARM64" />
+    <MSBuild Projects="..\extern\charls\src\CharLS.vcxproj" Targets="Build" Properties="Configuration=$(Configuration);Platform=Win32;CHARLS_DETERMINISTIC_BUILD=true" />
+    <MSBuild Projects="..\extern\charls\src\CharLS.vcxproj" Targets="Build" Properties="Configuration=$(Configuration);Platform=x64;CHARLS_DETERMINISTIC_BUILD=true" />
+    <MSBuild Projects="..\extern\charls\src\CharLS.vcxproj" Targets="Build" Properties="Configuration=$(Configuration);Platform=ARM64;CHARLS_DETERMINISTIC_BUILD=true" />
   </Target>
 
   <Target Name="CopyNativeWindowsCharLSFiles" BeforeTargets="Build" Condition="'$(MSBuildRuntimeType)'=='Full'">

--- a/src/CommentEventArgs.cs
+++ b/src/CommentEventArgs.cs
@@ -8,10 +8,6 @@ namespace CharLS.Native;
 /// </summary>
 public sealed class CommentEventArgs : EventArgs
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CommentEventArgs"/> class.
-    /// </summary>
-    /// <param name="data"></param>
     internal CommentEventArgs(byte[] data)
     {
         Data = data;

--- a/src/ExceptionExtensions.cs
+++ b/src/ExceptionExtensions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+namespace CharLS;
+
+/// <summary>
+/// Provides helper methods for Exception objects and JpegLSError values.
+/// </summary>
+public static class ExceptionExtensions
+{
+    /// <summary>
+    /// Retrieves the JpegLSError value from the Exception instance or None if no error value was present.
+    /// </summary>
+    public static JpegLSError GetJpegLSError(this Exception exception)
+    {
+        var value = exception.Data[nameof(JpegLSError)];
+        return value != null ? (JpegLSError)value : default;
+    }
+}

--- a/src/JpegLSEncoder.cs
+++ b/src/JpegLSEncoder.cs
@@ -314,7 +314,7 @@ public sealed class JpegLSEncoder : IDisposable
     /// Writes a comment (COM) segment to the destination.
     /// </summary>
     /// <remarks>
-    /// Function should be called before decoding the image.
+    /// Function should be called before encoding the image data.
     /// </remarks>
     /// <param name="comment">The 'comment' bytes. Application specific, usually human readable UTF-8 string.</param>
     public void WriteComment(ReadOnlySpan<byte> comment)
@@ -326,12 +326,26 @@ public sealed class JpegLSEncoder : IDisposable
     /// Writes a comment (COM) segment to the destination.
     /// </summary>
     /// <remarks>
-    /// Function should be called before decoding the image.
+    /// Function should be called before encoding the image data.
     /// </remarks>
     /// <param name="comment">Application specific value, usually human readable UTF-8 string.</param>
     public void WriteComment(string comment)
     {
         WriteComment(ToUtf8(comment).Span);
+    }
+
+    /// <summary>
+    /// Writes an application data (APPn) segment to the destination.
+    /// </summary>
+    /// <remarks>
+    /// Function should be called before encoding the image data.
+    /// </remarks>
+    /// <param name="applicationDataId">The ID of the application data segment in the range [0..15].</param>
+    /// <param name="applicationData">The 'application data' bytes. Application specific.</param>
+    public void WriteApplicationData(int applicationDataId, ReadOnlySpan<byte> applicationData)
+    {
+        HandleJpegLSError(CharLSWriteApplicationData(_encoder, applicationDataId,
+            ref MemoryMarshal.GetReference(applicationData), (nuint)applicationData.Length));
     }
 
     /// <summary>

--- a/src/JpegLSError.cs
+++ b/src/JpegLSError.cs
@@ -155,6 +155,11 @@ public enum JpegLSError
     EndOfImageMarkerNotFound = 28,
 
     /// <summary>
+    /// This error is returned when the SPIFF header is invalid.
+    /// </summary>
+    InvalidSpiffHeader = 29,
+
+    /// <summary>
     /// The argument for the width parameter is outside the range [1, 65535].
     /// </summary>
     InvalidArgumentWidth = 100,


### PR DESCRIPTION
* Add unit test for reading and writing applicatrion data.
* Don't use generic delegate (does not work with interop)
* Add method to validate SPIFF header
* Add method to retrieve JpegLSError from Exception object