### PR TITLE
Only perform code coverage on CharLS.Native.Test.dll

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,7 @@ jobs:
         !**\intermediates\**
       runInParallel: true
       codeCoverageEnabled: true
+      runSettingsFile: 'tests\CodeCoverage.runsettings'
 
   - task: VSTest@2
     displayName: 'Test Charls.Native (.NET Framework 4.8 x64)'
@@ -62,6 +63,7 @@ jobs:
         !**\intermediates\**
       runInParallel: true
       codeCoverageEnabled: true
+      runSettingsFile: 'tests\CodeCoverage.runsettings'
 
   - task: VSTest@2
     displayName: 'Test Charls.Native (.NET 6.0 x86)'
@@ -75,6 +77,7 @@ jobs:
         !**\intermediates\**
       runInParallel: true
       codeCoverageEnabled: true
+      runSettingsFile: 'tests\CodeCoverage.runsettings'
 
   - task: VSTest@2
     displayName: 'Test Charls.Native (.NET 6.0 x64)'
@@ -88,6 +91,7 @@ jobs:
         !**\intermediates\**
       runInParallel: true
       codeCoverageEnabled: true
+      runSettingsFile: 'tests\CodeCoverage.runsettings'
 
   - task: VSTest@2
     displayName: 'Test Charls.Native (.NET 7.0 x86)'
@@ -101,6 +105,7 @@ jobs:
         !**\intermediates\**
       runInParallel: true
       codeCoverageEnabled: true
+      runSettingsFile: 'tests\CodeCoverage.runsettings'
 
   - task: VSTest@2
     displayName: 'Test Charls.Native (.NET 7.0 x64)'
@@ -114,7 +119,7 @@ jobs:
         !**\intermediates\**
       runInParallel: true
       codeCoverageEnabled: true
-
+      runSettingsFile: 'tests\CodeCoverage.runsettings'
 
 - job: 'linux'
   pool:

--- a/tests/CodeCoverage.runsettings
+++ b/tests/CodeCoverage.runsettings
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>
+          <CodeCoverage>
+            <!-- Match assembly file paths: -->
+            <ModulePaths>
+              <Include>
+                <ModulePath>.*\CharLS.Native.Test.dll</ModulePath>
+              </Include>
+            </ModulePaths>
+
+            <!-- Match attributes on any code element: -->
+            <Attributes>
+              <Exclude>
+                <!-- Don't forget "Attribute" at the end of the name -->
+                <Attribute>^System\.Diagnostics\.DebuggerHiddenAttribute$</Attribute>
+                <Attribute>^System\.Diagnostics\.DebuggerNonUserCodeAttribute$</Attribute>
+                <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+                <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+              </Exclude>
+            </Attributes>
+
+            <!-- Match the path of the source files in which each method is defined: -->
+            <Sources>
+              <Exclude>
+                <Source>.*\\atlmfc\\.*</Source>
+                <Source>.*\\vctools\\.*</Source>
+                <Source>.*\\public\\sdk\\.*</Source>
+                <Source>.*\\microsoft sdks\\.*</Source>
+                <Source>.*\\vc\\include\\.*</Source>
+              </Exclude>
+            </Sources>
+
+            <!-- Match the company name property in the assembly: -->
+            <CompanyNames>
+              <Exclude>
+                <CompanyName>.*microsoft.*</CompanyName>
+              </Exclude>
+            </CompanyNames>
+
+            <!-- Match the public key token of a signed assembly: -->
+            <PublicKeyTokens>
+              <!-- Exclude Visual Studio extensions: -->
+              <Exclude>
+                <PublicKeyToken>^B77A5C561934E089$</PublicKeyToken>
+                <PublicKeyToken>^B03F5F7F11D50A3A$</PublicKeyToken>
+                <PublicKeyToken>^31BF3856AD364E35$</PublicKeyToken>
+                <PublicKeyToken>^89845DCD8080CC91$</PublicKeyToken>
+                <PublicKeyToken>^71E9BCE111E9429C$</PublicKeyToken>
+                <PublicKeyToken>^8F50407C4E9E73B6$</PublicKeyToken>
+                <PublicKeyToken>^E361AF139669C375$</PublicKeyToken>
+              </Exclude>
+            </PublicKeyTokens>
+
+            <!-- We recommend you do not change the following values: -->
+
+            <!-- Set this to True to collect coverage information for functions marked with the "SecuritySafeCritical" attribute. Instead of writing directly into a memory location from such functions, code coverage inserts a probe that redirects to another function, which in turns writes into memory. -->
+            <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+            <!-- When set to True, collects coverage information from child processes that are launched with low-level ACLs, for example, UWP apps. -->
+            <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+            <!-- When set to True, collects coverage information from child processes that are launched by test or production code. -->
+            <CollectFromChildProcesses>True</CollectFromChildProcesses>
+            <!-- When set to True, restarts the IIS process and collects coverage information from it. -->
+            <CollectAspDotNet>False</CollectAspDotNet>
+
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
Only perform code coverage of CharLS.Native.Test.dll. Code coverage of native DLLs (the C++ Charls DLL) seems to cause an instable CI pipeline and require the option /PROFILE for a good reliable code coverage report.