### PR TITLE
Use .NET 8.0.300 on CI pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,11 +25,6 @@ jobs:
 
   - task: NuGetToolInstaller@1
 
-  - task: UseDotNet@2
-    displayName: 'Install .NET 8.0.205 SDK'
-    inputs:
-      version: 8.0.205
-
   - task: NuGetCommand@2
     inputs:
       feedsToUse: config
@@ -64,6 +59,34 @@ jobs:
       otherConsoleOptions: --Framework:".NETFramework,Version=v4.8" --Platform:x64
       testAssemblyVer2: |
         **\net48\CharLS.Native.Test.dll
+        !**\*TestAdapter.dll
+        !**\intermediates\**
+      runInParallel: true
+      codeCoverageEnabled: true
+      runSettingsFile: 'tests\CodeCoverage.runsettings'
+
+  - task: VSTest@2
+    displayName: 'Test Charls.Native (.NET 6.0 x64)'
+    inputs:
+      platform: '$(buildPlatform)'
+      configuration: '$(buildConfiguration)'
+      otherConsoleOptions: --Framework:".NETCoreApp,Version=v6.0" --Platform:x64
+      testAssemblyVer2: |
+        **\net6.0\CharLS.Native.Test.dll
+        !**\*TestAdapter.dll
+        !**\intermediates\**
+      runInParallel: true
+      codeCoverageEnabled: true
+      runSettingsFile: 'tests\CodeCoverage.runsettings'
+
+  - task: VSTest@2
+    displayName: 'Test Charls.Native (.NET 7.0 x64)'
+    inputs:
+      platform: '$(buildPlatform)'
+      configuration: '$(buildConfiguration)'
+      otherConsoleOptions: --Framework:".NETCoreApp,Version=v7.0" --Platform:x64
+      testAssemblyVer2: |
+        **\net7.0\CharLS.Native.Test.dll
         !**\*TestAdapter.dll
         !**\intermediates\**
       runInParallel: true
@@ -139,7 +162,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET 8.0 SDK'
     inputs:
-      version: 8.0.205
+      version: 8.0.x
 
   - task: DotNetCoreCLI@2
     displayName: 'Restore NuGet packages'
@@ -224,7 +247,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Install .NET 8.0 SDK'
     inputs:
-      version: 8.0.205
+      version: 8.0.x
 
   - task: DotNetCoreCLI@2
     displayName: 'Restore NuGet packages'

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.205",
-    "rollForward": "latestPatch",
+    "version": "8.0.300",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
The standard images on the CI pipeline have been updated. There is no longer a need to use 8.0.205