### PR TITLE
Execute nuget restore before clean

### DIFF
--- a/create-signed-nuget-package.cmd
+++ b/create-signed-nuget-package.cmd
@@ -1,3 +1,3 @@
-msbuild -t:clean -p:Configuration=Release
 msbuild -t:restore -p:Configuration=Release
+msbuild -t:clean -p:Configuration=Release
 msbuild -t:pack -p:Configuration=Release -p:ContinuousIntegrationBuild=true -p:CertificateThumbprint=%1 -p:TimestampUrl=%2


### PR DESCRIPTION
Executing clean could fail when building with .NET 9.0 SDK.