### PR TITLE
Enable property IsAotCompatible

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,21 +27,9 @@ csharp_style_expression_bodied_accessors = true:silent
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
 csharp_style_throw_expression = true:suggestion
-
-[*.props]
-indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false
-
-[*.csproj]
-indent_size = 2
-
-[*.{cs,vb}]
-indent_size = 4
-tab_width = 4
-indent_size = 4
-end_of_line = crlf
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_space_around_binary_operators = before_and_after
 
 # New line preferences
 csharp_new_line_before_open_brace = all
@@ -69,15 +57,26 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 
 csharp_preserve_single_line_blocks = true
 
-csharp_style_expression_bodied_constructors = false:suggestion
-csharp_style_expression_bodied_methods = false:suggestion
-csharp_style_expression_bodied_properties = true:suggestion
 csharp_style_inlined_variable_declaration = false:suggestion
 csharp_style_var_for_built_in_types = false:none
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:none
-csharp_style_namespace_declarations = file_scoped:silent
-csharp_prefer_braces = when_multiline:suggestion
+
+resharper_remove_redundant_braces_highlighting = none
+
+[*.props]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.csproj]
+indent_size = 2
+
+[*.{cs,vb}]
+indent_size = 4
+tab_width = 4
+end_of_line = crlf
 
 dotnet_sort_system_directives_first = true
 
@@ -86,17 +85,6 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
-csharp_using_directive_placement = outside_namespace:silent
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_top_level_statements = true:silent
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_throw_expression = true:suggestion
-csharp_indent_labels = one_less_than_current
 
 #### Naming styles ####
 

--- a/CharLSNativeDotNet.sln
+++ b/CharLSNativeDotNet.sln
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Convert", "samples\Convert\Convert.csproj", "{54DD2338-FC32-4D1D-A07D-EDBDFDF13E60}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AotCompatibilityTestApp", "aot-compatilibity-test\AotCompatibilityTestApp.csproj", "{004141A9-45CF-4190-92EE-481B85004D2F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{54DD2338-FC32-4D1D-A07D-EDBDFDF13E60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54DD2338-FC32-4D1D-A07D-EDBDFDF13E60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54DD2338-FC32-4D1D-A07D-EDBDFDF13E60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{004141A9-45CF-4190-92EE-481B85004D2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{004141A9-45CF-4190-92EE-481B85004D2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{004141A9-45CF-4190-92EE-481B85004D2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{004141A9-45CF-4190-92EE-481B85004D2F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/aot-compatilibity-test/AotCompatibilityTestApp.csproj
+++ b/aot-compatilibity-test/AotCompatibilityTestApp.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <PublishAot Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\CharLS.Native.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/aot-compatilibity-test/Program.cs
+++ b/aot-compatilibity-test/Program.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Team CharLS.
+// SPDX-License-Identifier: BSD-3-Clause
+
+using CharLS.Native;
+
+var source = new byte[] { 7 };
+using var encoder = new JpegLSEncoder(1, 1, 8, 1);
+encoder.Encode(source);
+
+var destination = new byte[1];
+using var decoder = new JpegLSDecoder(encoder.EncodedData);
+decoder.Decode(destination);
+
+Console.WriteLine(source[0] != destination[0]
+    ? "Error: source and destination are not equal."
+    : "Success: source and destination are equal.");

--- a/src/CharLS.Native.csproj
+++ b/src/CharLS.Native.csproj
@@ -13,6 +13,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly> <!-- Explicit enable for build acceleration and target .NET 4.8 -->
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">true</IsAotCompatible>
 
     <!-- Use strong naming -->
     <SignAssembly>true</SignAssembly>

--- a/tests/JpegLSCodecTest.cs
+++ b/tests/JpegLSCodecTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Team CharLS.
 // SPDX-License-Identifier: BSD-3-Clause
 
-using System.Reflection;
 using NUnit.Framework;
 
 namespace CharLS.Native.Test;
@@ -337,11 +336,11 @@ internal sealed class JpegLSCodecTest
     {
         get
         {
-            var assemblyLocation = new Uri(Assembly.GetExecutingAssembly().Location);
+            string assemblyLocation = AppContext.BaseDirectory;
 #if NET8_0_OR_GREATER
-            return Path.Join(Path.GetDirectoryName(assemblyLocation.LocalPath), "DataFiles");
+            return Path.Join(Path.GetDirectoryName(assemblyLocation), "DataFiles");
 #else
-            return Path.Combine(Path.GetDirectoryName(assemblyLocation.LocalPath)!, "DataFiles");
+            return Path.Combine(Path.GetDirectoryName(assemblyLocation)!, "DataFiles");
 #endif
         }
     }

--- a/tests/JpegLSDecoderTest.cs
+++ b/tests/JpegLSDecoderTest.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using NUnit.Framework;
 
 namespace CharLS.Native.Test;
@@ -346,11 +345,12 @@ internal sealed class JpegLSDecoderTest
     {
         get
         {
-            Uri assemblyLocation = new(Assembly.GetExecutingAssembly().Location);
+            string assemblyLocation = AppContext.BaseDirectory;
+
 #if NET8_0_OR_GREATER
-            return Path.Join(Path.GetDirectoryName(assemblyLocation.LocalPath), "DataFiles");
+            return Path.Join(Path.GetDirectoryName(assemblyLocation), "DataFiles");
 #else
-            return Path.Combine(Path.GetDirectoryName(assemblyLocation.LocalPath)!, "DataFiles");
+            return Path.Combine(Path.GetDirectoryName(assemblyLocation)!, "DataFiles");
 #endif
         }
     }


### PR DESCRIPTION
Setting this property to true will enable additional analyzer to verify that the library is AOT compatible. Note: AOT compatibile also implies trimmable.