### PR TITLE
chores: Update version and sign thumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [4.1.0 - UNRELEASED]
 
 ### Changed
 
 - Switched to the artifacts output directory model.
 - Updated referenced NuGet packages.
 - Updated the minimal required Visual Studio version to 2026 when building for Windows
+- Updated CharLS binary for Windows to v2.3.4.
 
 ### Added
 

--- a/aot-compatibility-test/AotCompatibilityTestApp.csproj
+++ b/aot-compatibility-test/AotCompatibilityTestApp.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <PublishAot Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/create-signed-nuget-package.cmd
+++ b/create-signed-nuget-package.cmd
@@ -1,3 +1,3 @@
 msbuild -t:restore -p:Configuration=Release
 msbuild -t:clean -p:Configuration=Release
-msbuild -t:pack -p:Configuration=Release -p:ContinuousIntegrationBuild=true -p:CertificateThumbprint=%1 -p:TimestampUrl=%2
+msbuild -t:pack -p:Configuration=Release -p:ContinuousIntegrationBuild=true -p:CertificateThumbprint=%1 -p:CertificateThumbprint256=%2 -p:TimestampUrl=%3

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+  "version": "0.2",
+  "dictionaryDefinitions": [
+    {
+      "name": "project-words",
+      "path": "spelling.dic",
+      "addWords": true
+    }
+  ],
+  "dictionaries": ["project-words"],
+  "ignorePaths": ["spelling.dic"]
+}

--- a/spelling.dic
+++ b/spelling.dic
@@ -1,0 +1,8 @@
+HRES
+JBIG
+libcharls
+nunit
+resharper
+stylecop
+typeparam
+VRES

--- a/src/CharLS.Native.csproj
+++ b/src/CharLS.Native.csproj
@@ -6,9 +6,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>4.0.0</Version>
+    <Version>4.1.0</Version>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <FileVersion>4.0.0.0</FileVersion>
+    <FileVersion>4.1.0.0</FileVersion>
     <Copyright>Copyright 2024 Team CharLS</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -41,7 +41,9 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
     <_CertificateThumbprint>$(CertificateThumbprint)</_CertificateThumbprint>
-    <_CertificateThumbprint Condition="'$(_CertificateThumbprint)' == ''">b834c6c1d7e0ae8e76cadcf9e2e7a273133a5df6</_CertificateThumbprint>
+    <_CertificateThumbprint Condition="'$(_CertificateThumbprint)' == ''">0a0a208b4bcf6681eb32abc5a60ef1dee52903c6</_CertificateThumbprint>
+    <_CertificateThumbprint256 Condition="'$(_CertificateThumbprint256)' != ''">$(CertificateThumbprint256)</_CertificateThumbprint256>
+    <_CertificateThumbprint256 Condition="'$(_CertificateThumbprint256)' == ''">99E11E2A44D25F4AFA247A4074FB8655A223C69BB607024A9DCB03747654A0BE</_CertificateThumbprint256>
     <_TimestampUrl>$(TimestampUrl)</_TimestampUrl>
     <_TimestampUrl Condition="'$(_TimestampUrl)' == ''">http://time.certum.pl/</_TimestampUrl>
   </PropertyGroup>
@@ -107,16 +109,16 @@
   <Target Name="SignWindowsDlls" BeforeTargets="GenerateNuspec" Condition="'$(MSBuildRuntimeType)'=='Full'">
     <!-- Use TargetFrameworkVersion=v4.5 to sign with SHA256 -->
     <Message Text="Signing CharLS.Native.dll (.NET Framework 4.8)" />
-    <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath)net48\CharLS.Native.dll" TargetFrameworkVersion="v4.5" />
+    <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath.TrimEnd('\'))_net48\CharLS.Native.dll" TargetFrameworkVersion="v4.5" />
 
     <Message Text="Signing CharLS.Native.dll (.NET 8.0)" />
-    <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath)net8.0\CharLS.Native.dll" TargetFrameworkVersion="v4.5" />
+    <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath.TrimEnd('\'))_net8.0\CharLS.Native.dll" TargetFrameworkVersion="v4.5" />
 
     <Message Text="Signing CharLS.Native.dll (.NET 9.0)" />
-    <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath)net9.0\CharLS.Native.dll" TargetFrameworkVersion="v4.5" />
+    <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath.TrimEnd('\'))_net9.0\CharLS.Native.dll" TargetFrameworkVersion="v4.5" />
 
     <Message Text="Signing CharLS.Native.dll (.NET 10.0)" />
-    <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath)net10.0\CharLS.Native.dll" TargetFrameworkVersion="v4.5" />
+    <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath.TrimEnd('\'))_net10.0\CharLS.Native.dll" TargetFrameworkVersion="v4.5" />
 
     <Message Text="Signing charls-2-x64.dll" />
     <SignFile CertificateThumbprint="$(_CertificateThumbprint)" TimestampUrl="$(_TimestampUrl)" SigningTarget="$(OutputPath)charls-2-x64.dll" TargetFrameworkVersion="v4.5" />
@@ -129,8 +131,8 @@
   </Target>
 
   <Target Name="SignPackage" AfterTargets="Pack" Condition="'$(MSBuildRuntimeType)'=='Full'">
-    <Exec Command="nuget sign $(OutputPath)$(PackageId).$(Version).nupkg -Timestamper $(_TimestampUrl) -CertificateFingerprint $(_CertificateThumbprint)" />
-    <Exec Command="nuget sign $(OutputPath)$(PackageId).$(Version).snupkg -Timestamper $(_TimestampUrl) -CertificateFingerprint $(_CertificateThumbprint)" />
+    <Exec Command="nuget sign $(ArtifactsPath)\package\$(Configuration)\$(PackageId).$(Version).nupkg -Timestamper $(_TimestampUrl) -CertificateFingerprint $(_CertificateThumbprint256)" />
+    <Exec Command="nuget sign $(ArtifactsPath)\package\$(Configuration)\$(PackageId).$(Version).snupkg -Timestamper $(_TimestampUrl) -CertificateFingerprint $(_CertificateThumbprint256)" />
   </Target>
 
 </Project>

--- a/src/CharLS.Native.csproj
+++ b/src/CharLS.Native.csproj
@@ -42,7 +42,7 @@
 
     <_CertificateThumbprint>$(CertificateThumbprint)</_CertificateThumbprint>
     <_CertificateThumbprint Condition="'$(_CertificateThumbprint)' == ''">0a0a208b4bcf6681eb32abc5a60ef1dee52903c6</_CertificateThumbprint>
-    <_CertificateThumbprint256 Condition="'$(_CertificateThumbprint256)' != ''">$(CertificateThumbprint256)</_CertificateThumbprint256>
+    <_CertificateThumbprint256>$(CertificateThumbprint256)</_CertificateThumbprint256>
     <_CertificateThumbprint256 Condition="'$(_CertificateThumbprint256)' == ''">99E11E2A44D25F4AFA247A4074FB8655A223C69BB607024A9DCB03747654A0BE</_CertificateThumbprint256>
     <_TimestampUrl>$(TimestampUrl)</_TimestampUrl>
     <_TimestampUrl Condition="'$(_TimestampUrl)' == ''">http://time.certum.pl/</_TimestampUrl>

--- a/src/nuget-release-notes.txt
+++ b/src/nuget-release-notes.txt
@@ -1,4 +1,4 @@
-4.0.0
- - Added support for .NET 9.0
- - Removed support for .NET 6.0
- - Removed support for .NET 7.0
+4.1.0
+ - Added support for .NET 10.0
+ - Updated CharLS binary to v2.3.4
+ 


### PR DESCRIPTION
- Update the version to v4.1.0
- Update the public signing certificate thumbprint
- Update signing commands
- Add cspell.json
